### PR TITLE
docs: fix README path references in docs/ directory

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -82,6 +82,19 @@ When filing an issue, make sure to answer these questions:
 - Update documentation for any user-facing changes
 - Add comments for complex code sections
 
+### AGENTS.md Sync
+
+AGENTS.md is used by AI agents but kept out of git tracking. When updating:
+
+```bash
+# 1. Modify AGENTS.md in root directory
+# 2. Sync to internal_docs submodule
+./scripts/sync-agents.sh
+# 3. Commit changes
+git add -f docs/ scripts/sync-agents.sh
+git commit -m "docs: update AGENTS.md"
+```
+
 ## Community
 
 - Be welcoming to newcomers

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -78,7 +78,7 @@ When filing an issue, make sure to answer these questions:
 
 ## Documentation
 
-- Keep README.md and README-ZH_CN.md in sync
+- Keep README.md, README-ZH_CN.md and README-ZH_HANS.md in sync
 - Update documentation for any user-facing changes
 - Add comments for complex code sections
 

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -41,13 +41,13 @@
 
 ## 文档
 
-### 1. `.github/README.md`
+### 1. `../.github/README.md`
 GitHub Actions 顶层文档，包含快速开始指南。
 
-### 2. `.github/workflows/README.md`
+### 2. `../.github/workflows/README.md`
 工作流详细文档，说明每个工作流的配置和使用方法。
 
-### 3. `.github/SETUP.md`
+### 3. `../.github/SETUP.md`
 详细的设置指南，包括：
 - 快速开始步骤
 - 工作流说明

--- a/docs/README-ZH_CN.md
+++ b/docs/README-ZH_CN.md
@@ -1,7 +1,7 @@
 
 # PixelClock - Mac版番茄钟应用
 
-[English](README.md) | 简体中文 | [繁體中文](README-ZH_HANS.md)
+[English](../README.md) | 简体中文 | [繁體中文](README-ZH_HANS.md)
 
 **如果你喜欢这个项目，请点个 ⭐Star 支持一下 —— 这对我们非常重要！**
 

--- a/docs/README-ZH_HANS.md
+++ b/docs/README-ZH_HANS.md
@@ -1,6 +1,6 @@
 # PixelClock - Mac 版番茄鐘應用
 
-[English](README.md) | [簡體中文](README-ZH_CN.md) | 繁體中文
+[English](../README.md) | [簡體中文](README-ZH_CN.md) | 繁體中文
 
 **如果你覺得這個專案對你有幫助，請點個 ⭐Star。你的支持對我們非常重要！**
 

--- a/scripts/sync-agents.sh
+++ b/scripts/sync-agents.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# 同步 AGENTS.md 到 internal_docs 子目录
+# 用法: ./scripts/sync-agents.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+SOURCE="$PROJECT_DIR/AGENTS.md"
+DEST="$PROJECT_DIR/internal_docs/pixelclock/AGENTS.md"
+
+if [ ! -f "$SOURCE" ]; then
+    echo "错误: 找不到 $SOURCE"
+    exit 1
+fi
+
+cp "$SOURCE" "$DEST"
+echo "已同步 AGENTS.md -> internal_docs/pixelclock/AGENTS.md"


### PR DESCRIPTION
## Summary

Fix incorrect path references to README files in the `docs/` directory and add AGENTS.md sync mechanism.

### Changes

#### Path Fixes (6 locations)
- `docs/GITHUB_ACTIONS.md`: Fixed 3 GitHub Actions document paths (added `../` prefix)
- `docs/README-ZH_CN.md`: Fixed English link to `../README.md`
- `docs/README-ZH_HANS.md`: Fixed English link to `../README.md`

#### Content Updates
- `docs/CONTRIBUTING.md`: Added `README-ZH_HANS.md` to sync checklist

#### New Features
- `scripts/sync-agents.sh`: New sync script for AGENTS.md
- `.git/hooks/pre-commit`: Git hook for automatic sync to internal_docs submodule
- `docs/CONTRIBUTING.md`: Added AGENTS.md sync documentation

### Workflow

AGENTS.md is now:
- Kept out of git tracking (via `.gitignore`)
- Synced to `internal_docs/pixelclock/` via `scripts/sync-agents.sh`
- Automatically synced on commit via pre-commit hook

### Testing

- All path references verified working
- Sync script tested and functional