### PR TITLE
docs: add Japanese and Korean README versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # PixelClock - Pomodoro Timer for Mac
 
-English | [简体中文](docs/README-ZH_CN.md) | [繁體中文](docs/README-ZH_HANS.md) | [🌍 Website](https://free-pixel.github.io)
+English | [简体中文](docs/README-ZH_CN.md) | [繁體中文](docs/README-ZH_HANS.md) | [日本語](docs/README-JA.md) | [한국어](docs/README-KO.md) | [🌍 Website](https://free-pixel.github.io)
 
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 ![Last Commit](https://img.shields.io/github/last-commit/free-pixel/PixelClockApp)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -78,7 +78,7 @@ When filing an issue, make sure to answer these questions:
 
 ## Documentation
 
-- Keep README.md, README-ZH_CN.md and README-ZH_HANS.md in sync
+- Keep README.md, README-ZH_CN.md, README-ZH_HANS.md, README-JA.md and README-KO.md in sync
 - Update documentation for any user-facing changes
 - Add comments for complex code sections
 

--- a/docs/README-JA.md
+++ b/docs/README-JA.md
@@ -1,0 +1,48 @@
+
+# PixelClock - Mac用ポモドーロタイマー
+
+[English](../README.md) | [简体中文](README-ZH_CN.md) | [繁體中文](README-ZH_HANS.md) | [한국어](README-KO.md) | [🌍 Website](https://free-pixel.github.io)
+
+**このプロジェクトが役に立った場合は、⭐Star を押してください —— 您的サポートは非常に重要です！**
+
+PixelClock は、生産性向上を支援するポモドーロタイマーアプリです。ポモドーロの作業時間、タスク内容、休憩時間、長休憩時間を自由に設定できます。
+
+4つのポモドーロを完了すると、PixelClock は自動的に長時間休憩をトリガーし、リラックスしてリフレッシュできます。
+
+**主な機能：**
+
+- **カスタム時間設定**：ニーズに応じて作業時間、短休憩時間、長休憩時間を設定できます。
+- **進捗同期表示**：Mac のメニューバーに進捗バーがリアルタイムで表示され、時間の経過とともに赤いプログレスバーが円を徐々に満たし、作業の進捗をリアルタイムで反映します。
+- **長時間休憩リマインダー**：4つのポモドーロを完了すると、アプリは自動的に長時間休憩を開始し、効率的でバランスの取れた作業ペースを維持できます。
+
+**インターフェース展示：**
+
+- **進捗バーインターフェース：**
+
+  <img src="https://github.com/user-attachments/assets/7b283f20-4e1a-4f61-9720-f7d525b1f7ac" width="800px" height="auto"/>
+
+  メニューバーにリアルタイム表示される赤い進捗バーで、作業の進捗を簡単に追跡できます。
+
+- **基本インターフェース：**
+
+  <img src="https://github.com/user-attachments/assets/a839c67e-c735-4f06-b87a-7d231acbf215" width="auto" height="400px"/>
+
+  直感的なタスク管理与時間設定インターフェース。
+
+- **長時間休憩インターフェース：**
+
+  <img src="https://github.com/user-attachments/assets/0abbb3f0-ad56-4d94-89dc-71f973921e27" width="auto" height="400px"/>
+
+  作業完了後、システムは自動的に長時間休憩モードに切り替わり、十分な回復時間を確保します。
+
+**注意**
+
+は現在 Mac OS 15.4.1 システムバージョンでアプリケーションを構築しています。このアプリが正常に動作しない場合は、このコードレポジトリをクローンして自行でコンパイルしてください。
+
+**機能概要：**
+
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/25a14b53-dd4b-4c14-930a-44057b851b0e" width="20%" style="display:inline-block; margin-right:1%;" />
+  <img src="https://github.com/user-attachments/assets/a839c67e-c735-4f06-b87a-7d231acbf215" width="20%" style="display:inline-block; margin-right:1%;" />
+  <img src="https://github.com/user-attachments/assets/0abbb3f0-ad56-4d94-89dc-71f973921e27" width="20%" style="display:inline-block;" />
+</p>

--- a/docs/README-KO.md
+++ b/docs/README-KO.md
@@ -1,7 +1,7 @@
 
 # PixelClock - Mac용 포모도로 타이머
 
-[English](../README.md) | [简体中文](README-ZH_CN.md) | [繁體中文](README-ZH_HANS.md) | [日本語](README-JA.md) | [🌍 Website](https://free-pixel.github.io)
+[English](../README.md) | [简体中文](README-ZH_CN.md) | [繁體中文](README-ZH_HANS.md) | [日本語](README-JA.md) | 한국어 | [🌍 Website](https://free-pixel.github.io)
 
 **이 프로젝트가 도움이 되었다면 ⭐Star 를 눌러주세요 —— 당신의 지원은 우리에게 매우 중요합니다!**
 

--- a/docs/README-KO.md
+++ b/docs/README-KO.md
@@ -1,0 +1,48 @@
+
+# PixelClock - Mac용 포모도로 타이머
+
+[English](../README.md) | [简体中文](README-ZH_CN.md) | [繁體中文](README-ZH_HANS.md) | [日本語](README-JA.md) | [🌍 Website](https://free-pixel.github.io)
+
+**이 프로젝트가 도움이 되었다면 ⭐Star 를 눌러주세요 —— 당신의 지원은 우리에게 매우 중요합니다!**
+
+PixelClock은 생산성 향상을 돕기 위한 포모도로 타이머 앱입니다. 포모도로 작업 시간, 작업 내용, 휴식 시간 및 긴 휴식 시간을 맞춤 설정할 수 있습니다.
+
+4개의 포모도로를 완료하면 PixelClock은 자동으로 긴 휴식을 트리거하여 휴식과 재충전을 돕습니다.
+
+**주요 기능:**
+
+- **맞춤형 시간 설정**: 필요에 따라 작업 시간, 짧은 휴식 시간 및 긴 휴식 시간을 설정합니다.
+- **진행 동기화 표시**: Mac 메뉴 표시줄의 진행 막대가 타이머와 동기화됩니다. 시간이 지남에 따라 빨간색 진행 막대가 원을 점진적으로 채워 작업 진행 상황을 실시간으로 반영합니다.
+- **긴 휴식 알림**: 4개의 포모도로를 완료하면 앱이 자동으로 긴 휴식을 시작하여 효율적이고 균형 잡힌 작업 속도를 유지하는 데 도움이 됩니다.
+
+**인터페이스 소개:**
+
+- **진행 막대 인터페이스:**
+
+  <img src="https://github.com/user-attachments/assets/7b283f20-4e1a-4f61-9720-f7d525b1f7ac" width="800px" height="auto"/>
+
+  메뉴 표시줄에 실시간으로 표시되는 빨간색 진행 막대로 작업 진행 상황을 쉽게 추적할 수 있습니다.
+
+- **기본 인터페이스:**
+
+  <img src="https://github.com/user-attachments/assets/a839c67e-c735-4f06-b87a-7d231acbf215" width="auto" height="400px"/>
+
+  직관적인 작업 관리 및 시간 설정 인터페이스.
+
+- **긴 휴식 인터페이스:**
+
+  <img src="https://github.com/user-attachments/assets/0abbb3f0-ad56-4d94-89dc-71f973921e27" width="auto" height="400px"/>
+
+  작업 완료 후 시스템은 자동으로 긴 휴식 모드로 전환되어 충분한 회복 시간을 보장합니다.
+
+**주의 사항**
+
+는 현재 Mac OS 15.4.1 시스템 버전에서 이 애플리케이션을 구축하고 있습니다. 애플리케이션이 정상적으로 작동하지 않으면 코드 저장소를 복제하여 직접 컴파일할 수 있습니다.
+
+**기능 개요:**
+
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/25a14b53-dd4b-4c14-930a-44057b851b0e" width="20%" style="display:inline-block; margin-right:1%;" />
+  <img src="https://github.com/user-attachments/assets/a839c67e-c735-4f06-b87a-7d231acbf215" width="20%" style="display:inline-block; margin-right:1%;" />
+  <img src="https://github.com/user-attachments/assets/0abbb3f0-ad56-4d94-89dc-71f973921e27" width="20%" style="display:inline-block;" />
+</p>

--- a/docs/README-ZH_CN.md
+++ b/docs/README-ZH_CN.md
@@ -1,7 +1,7 @@
 
 # PixelClock - Mac版番茄钟应用
 
-[English](../README.md) | 简体中文 | [繁體中文](README-ZH_HANS.md)
+[English](../README.md) | 简体中文 | [繁體中文](README-ZH_HANS.md) | [日本語](README-JA.md) | [한국어](README-KO.md)
 
 **如果你喜欢这个项目，请点个 ⭐Star 支持一下 —— 这对我们非常重要！**
 

--- a/docs/README-ZH_HANS.md
+++ b/docs/README-ZH_HANS.md
@@ -1,6 +1,6 @@
 # PixelClock - Mac 版番茄鐘應用
 
-[English](../README.md) | [簡體中文](README-ZH_CN.md) | 繁體中文
+[English](../README.md) | [簡體中文](README-ZH_CN.md) | 繁體中文 | [日本語](README-JA.md) | [한국어](README-KO.md)
 
 **如果你覺得這個專案對你有幫助，請點個 ⭐Star。你的支持對我們非常重要！**
 


### PR DESCRIPTION
## Summary

Add Japanese (JA) and Korean (KO) translations of README to improve internationalization.

### New Files

- `docs/README-JA.md` - Japanese translation
- `docs/README-KO.md` - Korean translation

### Updates

- Updated language navigation in:
  - `README.md` (root)
  - `docs/README-ZH_CN.md`
  - `docs/README-ZH_HANS.md`
- Updated `docs/CONTRIBUTING.md` sync checklist to include new languages

### Translation Coverage

| File | Status |
|------|--------|
| English | ✅ Original |
| 简体中文 | ✅ Existing |
| 繁體中文 | ✅ Existing |
| 日本語 | 🆕 New |
| 한국어 | 🆕 New |

All translations follow the same structure and formatting as existing versions.